### PR TITLE
Do not always connect the debugger when the protocol supports it

### DIFF
--- a/client-lib/src/main/kotlin/com/icapps/niddler/lib/adb/ADBInterface.kt
+++ b/client-lib/src/main/kotlin/com/icapps/niddler/lib/adb/ADBInterface.kt
@@ -110,7 +110,7 @@ class ADBDevice(device: JadbDevice, private val bootstrap: ADBBootstrap) {
                     line?.let {
                         val fromJson = Gson().fromJson<List<NiddlerAnnouncementMessage>>(line,
                                 createGsonListType<NiddlerAnnouncementMessage>())
-                        fromJson.map { NiddlerSession(this, it.packageName, it.port, it.pid) }
+                        fromJson.map { NiddlerSession(this, it.packageName, it.port, it.pid, it.protocol) }
                     }
                 } catch (e: IOException) {
                     log.debug("Failed to read announcement line", e)
@@ -127,10 +127,12 @@ class ADBDevice(device: JadbDevice, private val bootstrap: ADBBootstrap) {
 data class NiddlerSession(val device: ADBDevice,
                           val packageName: String,
                           val port: Int,
-                          val pid: Int)
+                          val pid: Int,
+                          val protocolVersion: Int)
 
 private data class NiddlerAnnouncementMessage(
         val packageName: String,
         val port: Int,
-        val pid: Int
+        val pid: Int,
+        val protocol: Int
 )

--- a/client-lib/src/main/kotlin/com/icapps/niddler/lib/connection/NiddlerClient.kt
+++ b/client-lib/src/main/kotlin/com/icapps/niddler/lib/connection/NiddlerClient.kt
@@ -19,7 +19,7 @@ import java.util.*
  * @author Nicola Verbeeck
  * @date 14/11/2016.
  */
-class NiddlerClient(serverURI: URI?, val widthDebugger: Boolean) : WebSocketClient(serverURI, Draft_6455()),
+class NiddlerClient(serverURI: URI?, val withDebugger: Boolean) : WebSocketClient(serverURI, Draft_6455()),
         NiddlerMessageListener, NiddlerDebugListener, NiddlerDebuggerConnection {
 
     companion object {

--- a/client-lib/src/main/kotlin/com/icapps/niddler/lib/connection/NiddlerClient.kt
+++ b/client-lib/src/main/kotlin/com/icapps/niddler/lib/connection/NiddlerClient.kt
@@ -19,7 +19,7 @@ import java.util.*
  * @author Nicola Verbeeck
  * @date 14/11/2016.
  */
-class NiddlerClient(serverURI: URI?) : WebSocketClient(serverURI, Draft_6455()),
+class NiddlerClient(serverURI: URI?, val widthDebugger: Boolean) : WebSocketClient(serverURI, Draft_6455()),
         NiddlerMessageListener, NiddlerDebugListener, NiddlerDebuggerConnection {
 
     companion object {

--- a/niddler-ui/src/main/kotlin/com/icapps/niddler/ui/form/NiddlerWindow.kt
+++ b/niddler-ui/src/main/kotlin/com/icapps/niddler/ui/form/NiddlerWindow.kt
@@ -42,8 +42,8 @@ class NiddlerWindow(private val windowContents: NiddlerUserInterface, private va
     : NiddlerMessageListener, ParsedNiddlerMessageListener<ParsedNiddlerMessage>, NiddlerMessagePopupMenu.Listener,
         NiddlerMainToolbar.ToolbarListener {
 
-    private companion object {
-        private const val PROTCOL_VERSION_DEBUGGING = 4
+    companion object {
+        const val PROTCOL_VERSION_DEBUGGING = 4
     }
 
     private val bodyParser = NiddlerMessageBodyParser(HeaderBodyClassifier())
@@ -125,7 +125,13 @@ class NiddlerWindow(private val windowContents: NiddlerUserInterface, private va
 
         windowContents.connectButtonListener = {
             val selection = NiddlerConnectDialog.showDialog(SwingUtilities.getWindowAncestor(windowContents.asComponent),
-                    adbConnection, null, null)
+                    adbConnection, null, null, withDebugger = false)
+            if (selection != null)
+                onDeviceSelectionChanged(selection)
+        }
+        windowContents.debugButtonListener = {
+            val selection = NiddlerConnectDialog.showDialog(SwingUtilities.getWindowAncestor(windowContents.asComponent),
+                    adbConnection, null, null, withDebugger = true)
             if (selection != null)
                 onDeviceSelectionChanged(selection)
         }
@@ -181,9 +187,9 @@ class NiddlerWindow(private val windowContents: NiddlerUserInterface, private va
 
     private fun onDeviceSelectionChanged(params: NiddlerConnectDialog.ConnectSelection) {
         when {
-            params.session != null -> initNiddlerOnSession(params.session)
-            params.device != null -> initNiddlerOnDevice(params.device, params.port)
-            else -> initNiddlerOnDevice(params.ip!!)
+            params.session != null -> initNiddlerOnSession(params.session, params.withDebugger)
+            params.device != null -> initNiddlerOnDevice(params.device, params.port, params.withDebugger)
+            else -> initNiddlerOnDevice(params.ip!!, params.withDebugger)
         }
     }
 
@@ -200,24 +206,24 @@ class NiddlerWindow(private val windowContents: NiddlerUserInterface, private va
         onClosed()
     }
 
-    private fun initNiddlerOnSession(session: NiddlerSession) {
+    private fun initNiddlerOnSession(session: NiddlerSession, withDebugger: Boolean) {
         session.device.forwardTCPPort(6555, session.port)
-        initNiddlerOnDevice("127.0.0.1:6555")
+        initNiddlerOnDevice("127.0.0.1:6555", withDebugger)
     }
 
-    private fun initNiddlerOnDevice(adbDevice: ADBDevice, port: Int) {
+    private fun initNiddlerOnDevice(adbDevice: ADBDevice, port: Int, withDebugger: Boolean) {
         adbDevice.forwardTCPPort(6555, port)
-        initNiddlerOnDevice("127.0.0.1:6555")
+        initNiddlerOnDevice("127.0.0.1:6555", withDebugger)
     }
 
-    private fun initNiddlerOnDevice(ip: String) {
+    private fun initNiddlerOnDevice(ip: String, withDebugger: Boolean) {
         disconnect()
         messages.storage.clear()
 
         val tempUri = URI.create("sis://$ip")
         val port = if (tempUri.port == -1) 6555 else tempUri.port
 
-        val niddlerClient = NiddlerClient(URI.create("ws://${tempUri.host}:$port")).apply {
+        val niddlerClient = NiddlerClient(URI.create("ws://${tempUri.host}:$port"), withDebugger).apply {
             registerMessageListener(this@NiddlerWindow)
             messages.attach(this)
         }
@@ -348,7 +354,7 @@ class NiddlerWindow(private val windowContents: NiddlerUserInterface, private va
             //TODO windowContents.updateProtocol(serverInfo.protocol)
             windowContents.statusBar.onApplicationInfo(serverInfo)
         }
-        if (serverInfo.protocol >= PROTCOL_VERSION_DEBUGGING) {
+        if (serverInfo.protocol >= PROTCOL_VERSION_DEBUGGING && niddlerClient!!.widthDebugger) {
             val debuggerInterface = ServerDebuggerInterface(
                     DebuggerService(niddlerClient!!))
             debuggerInterface.connect()

--- a/niddler-ui/src/main/kotlin/com/icapps/niddler/ui/form/NiddlerWindow.kt
+++ b/niddler-ui/src/main/kotlin/com/icapps/niddler/ui/form/NiddlerWindow.kt
@@ -354,7 +354,7 @@ class NiddlerWindow(private val windowContents: NiddlerUserInterface, private va
             //TODO windowContents.updateProtocol(serverInfo.protocol)
             windowContents.statusBar.onApplicationInfo(serverInfo)
         }
-        if (serverInfo.protocol >= PROTCOL_VERSION_DEBUGGING && niddlerClient!!.widthDebugger) {
+        if (serverInfo.protocol >= PROTCOL_VERSION_DEBUGGING && niddlerClient!!.withDebugger) {
             val debuggerInterface = ServerDebuggerInterface(
                     DebuggerService(niddlerClient!!))
             debuggerInterface.connect()

--- a/niddler-ui/src/main/kotlin/com/icapps/niddler/ui/form/impl/SwingNiddlerUserInterface.kt
+++ b/niddler-ui/src/main/kotlin/com/icapps/niddler/ui/form/impl/SwingNiddlerUserInterface.kt
@@ -28,6 +28,7 @@ open class SwingNiddlerUserInterface(override val componentsFactory: ComponentsF
     override var connectButtonListener: (() -> Unit)? = null
     override var filterListener: ((String?) -> Unit)? = null
     override var disconnectButtonListener: (() -> Unit)? = null
+    override var debugButtonListener: (() -> Unit)? = null
 
     override val asComponent: JComponent
         get() = rootPanel
@@ -93,7 +94,7 @@ open class SwingNiddlerUserInterface(override val componentsFactory: ComponentsF
             connectButtonListener?.invoke()
         }
         toolbar.addAction("/startDebugger.png".loadIcon<AbstractToolbar>(), "Connect with debugger") {
-            //TODO
+            debugButtonListener?.invoke()
         }
         disconnectButton = toolbar.addAction("/suspend.png".loadIcon<AbstractToolbar>(), "Disconnect") {
             it.isEnabled = false

--- a/niddler-ui/src/main/kotlin/com/icapps/niddler/ui/form/ui/NiddlerUserInterface.kt
+++ b/niddler-ui/src/main/kotlin/com/icapps/niddler/ui/form/ui/NiddlerUserInterface.kt
@@ -19,6 +19,7 @@ interface NiddlerUserInterface {
     var connectButtonListener: (() -> Unit)?
     var filterListener: ((String?) -> Unit)?
     var disconnectButtonListener: (() -> Unit)?
+    var debugButtonListener: (() -> Unit)?
 
     val toolbar: NiddlerMainToolbar
     val disconnectButton: Component


### PR DESCRIPTION
Make debug button do something
Warn clients when debugging is not enabled for a autodiscovered session (protocol too old)
Reload list of sessions every x seconds